### PR TITLE
Increase container height for item overflow (iOS)

### DIFF
--- a/lib/RefreshableFlatList.ios.js
+++ b/lib/RefreshableFlatList.ios.js
@@ -39,6 +39,7 @@ export default class RefreshableFlatList extends Component {
     onRefreshing: PropTypes.func,
     onLoadMore: PropTypes.func,
     minDisplayTime: PropTypes.number,
+    overflowHeight: PropTypes.number,
     onScroll: PropTypes.func,
     showTopIndicator: PropTypes.bool,
     showBottomIndicator: PropTypes.bool,
@@ -64,6 +65,7 @@ export default class RefreshableFlatList extends Component {
     minPullUpDistance: 54,
     scrollEventThrottle: 16,
     minDisplayTime: 300,
+    overflowHeight: 0,
     showTopIndicator: true,
     showBottomIndicator: true,
     topIndicatorComponent: Indicator,
@@ -196,12 +198,12 @@ export default class RefreshableFlatList extends Component {
         this.scrollContainer.setNativeProps({
           style: {
             width: e.nativeEvent.layout.width,
-            height: e.nativeEvent.layout.height
+            height: e.nativeEvent.layout.height + this.props.overflowHeight
           }
         });
       }
 
-      this.setState({ width: e.nativeEvent.layout.width, height: e.nativeEvent.layout.height });
+      this.setState({ width: e.nativeEvent.layout.width, height: e.nativeEvent.layout.height + this.props.overflowHeight });
     }
   }
 


### PR DESCRIPTION
For customization, the top/bottom indicator does not display if the content height (total item height) is greater than the scrollable container height. This simple fix will allow a user to increase the scrollable container height when the layout is initialized.